### PR TITLE
Remove depedency on codecommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,25 @@ This solution follows prescriptive guidance for automating remediations for AWS 
 2. The request invokes a large language model (LLM) with context from a knowledge base containing AWS documentation stored as embeddings in an Amazon OpenSearch vector database.
 
 3. The LLM generates instructions for an action group that invokes the Remediation Generator AWS Lambda function to create a Systems Manager automation document.
-4. The automation document is published to an AWS CodeCommit repository. 
+4. The automation document is published to a git repository. 
    If the CFN_EXEC_ROLE_ARN context parameter is provided, a CloudFormation StackSet is created from the automation document template and StackSet instances are created in the provided WORKLOAD_ACCOUNTS and current AWS region. Otherwise, the CloudFormation stack is deployed directly using aws cloudformation deploy command.
 5. The SecOps user updates parameter files for the automation in a document management system folder, triggering AWS CodePipeline.
-1. The SecOps user utilizes the Agents for Amazon Bedrock chat console to enter their responses (e.g. "Generate automation for remediation of database migration service replication instances should not be public"). Optionally, findings can be exported from Security Hub to an Amazon S3 bucket.
+6. The SecOps user utilizes the Agents for Amazon Bedrock chat console to enter their responses (e.g. "Generate automation for remediation of database migration service replication instances should not be public"). Optionally, findings can be exported from Security Hub to an Amazon S3 bucket.
 
-2. The request invokes a large language model (LLM) with context from a knowledge base containing AWS documentation stored as embeddings in an Amazon OpenSearch vector database.
+7. The request invokes a large language model (LLM) with context from a knowledge base containing AWS documentation stored as embeddings in an Amazon OpenSearch vector database.
 
-3. The LLM generates instructions for an action group that invokes the Remediation Generator AWS Lambda function to create a Systems Manager automation document.
+8. The LLM generates instructions for an action group that invokes the Remediation Generator AWS Lambda function to create a Systems Manager automation document.
 
-4. The automation document is published to an AWS CodeCommit repository.
-5. The SecOps user updates parameter files for the automation in a document management system folder, triggering AWS CodePipeline.
+9. The automation document is published to a git repository.
+10. The SecOps user updates parameter files for the automation in a document management system folder, triggering AWS CodePipeline.
 
-6. AWS CodeBuild runs cfn-lint and cfn-nag validations on the CloudFormation template.
+11. AWS CodeBuild runs cfn-lint and cfn-nag validations on the CloudFormation template.
 
-7. An Amazon SNS notification is sent to the SecOps user group for approval before deployment.
+12. An Amazon SNS notification is sent to the SecOps user group for approval before deployment.
 
-8. The approved Systems Manager automation document is executed.
+13. The approved Systems Manager automation document is executed.
 
-9. The SecOps user validates the compliance status for the remediated finding in the Security Hub console.
+14. The SecOps user validates the compliance status for the remediated finding in the Security Hub console.
 
 ### Deployment
 
@@ -70,28 +70,37 @@ Follow these steps to deploy the CDK application:
     
     - If `CFN_EXEC_ROLE_NAME` is provided, the solution will be deployed as a CloudFormation StackSet to the specified WORKLOAD_ACCOUNTS.
     - If `CFN_EXEC_ROLE_NAME` is not provided, the solution will be deployed only to the current account.
+  
+      > **IMPORTANT**: The following steps are required for GitHub integration. If you choose to use a different source control provider, you may do so, but you will need to edit the committer class accordingly. This is crucial for the proper functioning of the solution with your chosen source control system.
+  
+      **GitHub Setup** 
+         1. Create a GitHub personal access token with repo and admin:repo_hook permissions.
+         2. Store the token in AWS Secrets Manager with the name 'github-token'.
+         3. Update the `cdk.json` file with your GitHub information:
+               - Set "GITHUB_OWNER" to your GitHub username
+               - Set "GITHUB_REPO" to your repository name
+               - Set "GITHUB_BRANCH" to the branch you want to use (default is 'main')
 
    - Synthesize CDK app. Run the following command to synthesize the CDK app and generate the CloudFormation template: `cdk synth`
-   - Deploy CDK app. Finally, deploy the solution to your AWS environment using the following command: `cdk deploy --all`. This command will deploy all the necessary resources, including the Remediation Generator Lambda function, the CodeCommit repository, the CodePipeline, and other required components.
+   - Deploy CDK app. Finally, deploy the solution to your AWS environment using the following command: `cdk deploy --all`. This command will deploy all the necessary resources, including the Remediation Generator Lambda function, the CodePipeline, and other required components.
 
 ### File Details
 
-The `app.py` file is the main entry point for the CDK application. It defines the CDK stack and its resources, such as Lambda functions, CodeCommit repositories, CodePipelines, and more.
+The `app.py` file is the main entry point for the CDK application. It defines the CDK stack and its resources, such as Lambda functions, CodePipelines, and more.
 
 1. **Imports**: The file starts by importing the necessary modules and classes from the AWS CDK and other libraries.
 
 2. **Stack Definition**: The `AwsBedRockLangchainPythonCdkStack` class extends the `Stack` class from the AWS CDK. It contains the definitions for all the resources that will be deployed.
 
-3. **Parameters**: The `AwsBedRockLangchainPythonCdkStack` class constructor accepts several parameters, such as the AWS region, the Amazon Bedrock knowledge base ID, and the CodeCommit repository branch.
+3. **Parameters**: The `AwsBedRockLangchainPythonCdkStack` class constructor accepts several parameters, such as the AWS region, the Amazon Bedrock knowledge base ID, and the git repository repository branch.
 
 4. **Resource Definitions**:
-   - **CodeCommit Repository**: A CodeCommit repository is created to store the Systems Manager automation documents.
    - **Remediation Generator Lambda Function**: A Lambda function is created to generate the Systems Manager automation documents based on the input from the Amazon Bedrock agent.
    - **Other Resources**: Depending on the specific requirements, additional resources like S3 buckets, SNS topics, and IAM roles may be defined.
 
 5. **Resource Dependencies**: The stack defines dependencies between resources to ensure the correct order of deployment.
 
-6. **Outputs**: The stack may define outputs to display relevant information after deployment, such as the CodeCommit repository URL or the Remediation Generator Lambda function ARN.
+6. **Outputs**: The stack may define outputs to display relevant information after deployment, such as the Remediation Generator Lambda function ARN.
 
 The `index.py` file contains the code for the Remediation Generator Lambda function. This function is responsible for generating the Systems Manager automation documents based on the input from the Amazon Bedrock agent.
 
@@ -103,7 +112,7 @@ The `index.py` file contains the code for the Remediation Generator Lambda funct
 
 4. **Document Generation**: Based on the input, the function generates the Systems Manager automation document. This may involve parsing the input, retrieving relevant information from the knowledge base, and constructing the document using predefined templates or logic.
 
-5. **Document Storage**: Once the automation document is generated, the function stores it in the CodeCommit repository specified in the stack.
+5. **Document Storage**: Once the automation document is generated, the function stores it in the git repository specified in the stack.
 
 6. **Output**: The function may return a response indicating the successful generation and storage of the automation document.
 

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ app = cdk.App()
 
 
 aws_bedrock_langchain_stack = AwsBedrockLangchainPythonCdkStack(app, "AwsBedrockLangchainPythonCdkStack")
-aws_bedrock_langchain_codepipeline_stack = AwsBedrockLangchainCodePipelineStack(app, "AwsBedrockLangchainCodePipeline", codecommit_repo=aws_bedrock_langchain_stack.codecommit_repo)
+aws_bedrock_langchain_codepipeline_stack = AwsBedrockLangchainCodePipelineStack(app, "AwsBedrockLangchainCodePipeline")
 
 Aspects.of(app).add(cdk_nag.AwsSolutionsChecks(reports=True, verbose=True))
 

--- a/aws_bedrock_langchain_python_cdk/lambda/code/langchain/gitHubCommit.py
+++ b/aws_bedrock_langchain_python_cdk/lambda/code/langchain/gitHubCommit.py
@@ -1,0 +1,53 @@
+import logging
+from github import Github, GithubException
+import boto3
+
+logging.basicConfig(level=logging.INFO)
+
+class GitHubCommitter:
+    def __init__(self, github_repo):
+        # Retrieving GitHub access token from secrets manager 'github-token' secret.
+        self.client = boto3.client('secretsmanager')
+        try:
+            self.oauth_token = self.client.get_secret_value(SecretId='github-token')['SecretString']
+        except Exception as e:
+            logging.error(f"Failed to retrieve GitHub token: {str(e)}")
+            raise
+        self.g = Github(self.oauth_token)
+        self.repo = self.g.get_repo(github_repo)
+        self.default_branch = self.repo.default_branch
+
+    def read_file_content(self, filepath):
+        with open(filepath, 'r') as file:
+            return file.read()
+
+    def create_file_path(self, resource_type, filename):
+        return f'{resource_type}/GenRem-{filename}.yaml'
+
+    def update_or_create_file(self, file_path, commit_message, file_content):
+        try:
+            # Try to get the file contents
+            file = self.repo.get_contents(file_path, ref=self.default_branch)
+            # If successful, update the existing file
+            return self.repo.update_file(file_path, commit_message, file_content, file.sha, branch=self.default_branch)
+        except GithubException as e:
+            if e.status == 404:
+                # If file not found, create a new file
+                return self.repo.create_file(file_path, commit_message, file_content, branch=self.default_branch)
+            else:
+                # If it's a different kind of error, re-raise it
+                raise
+
+    def commit_file(self, filename, filepath, resource_type):
+        file_content = self.read_file_content(filepath)
+        file_path = self.create_file_path(resource_type, filename)
+        commit_message = f"Push the remediation template for the security hub finding - {resource_type}"
+
+        try:
+            commit_response = self.update_or_create_file(file_path, commit_message, file_content)
+            logging.info(f"File operation successful: {file_path}")
+        except GithubException as e:
+            logging.error(f"Error committing file: {e}")
+            raise
+
+        return commit_response, file_path

--- a/aws_bedrock_langchain_python_cdk/lambda/layer/boto3_latest/requirements.txt
+++ b/aws_bedrock_langchain_python_cdk/lambda/layer/boto3_latest/requirements.txt
@@ -1,1 +1,2 @@
 boto3
+PyGithub

--- a/aws_bedrock_langchain_python_cdk/lambda/layer/langchain_latest/requirements.txt
+++ b/aws_bedrock_langchain_python_cdk/lambda/layer/langchain_latest/requirements.txt
@@ -1,2 +1,2 @@
-langchain
+langchain_community
 pydantic>=2.0.3

--- a/cdk.json
+++ b/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "python3 app.py",
+  "app": "python app.py",
   "watch": {
     "include": [
       "**"
@@ -15,12 +15,14 @@
     ]
   },
   "context": {
+    "GITHUB_OWNER": "<GITHUB_USERNAME>",
+    "GITHUB_REPO": "<REPO_NAME>",
     "MODEL_ID": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "KB_ID": "<KB_ID>",
+    "KB_ID": "<KNOWLEDGEBASE_ID>",
     "NOTIFICATION_EMAILS": ["<EMAIL>"],
     "BEDROCK_AGENT_ARN": "<BEDROCK_AGENT_ARN>",
     "CFN_EXEC_ROLE_NAME": "",
-    "WORKLOAD_ACCOUNTS": "0000000000 1111111111",
+    "WORKLOAD_ACCOUNTS": "",
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/tests/test_aws_bedrock_langchain_codepipeline_stack.py
+++ b/tests/test_aws_bedrock_langchain_codepipeline_stack.py
@@ -1,25 +1,41 @@
 import aws_cdk as cdk
 import aws_cdk.assertions as assertions
-import aws_cdk.aws_codecommit as codecommit
 from aws_bedrock_langchain_python_cdk.aws_bedrock_langchain_codepipeline_stack import AwsBedrockLangchainCodePipelineStack
 
 def test_codepipeline_created():
-    app = cdk.App()
+    app = cdk.App(context={
+        "GITHUB_OWNER": "test-owner",
+        "GITHUB_REPO": "test-repo",
+        "GITHUB_BRANCH": "main"
+    })
     stack = cdk.Stack(app, "TestStack")
-    codecommit_repo = codecommit.Repository.from_repository_name(stack, "CodeCommitRepo", "genai_remediations")
-    pipeline_stack = AwsBedrockLangchainCodePipelineStack(stack, "PipelineStack", codecommit_repo=codecommit_repo)
+    pipeline_stack = AwsBedrockLangchainCodePipelineStack(stack, "PipelineStack")
 
-    pipeline = pipeline_stack.node.find_child("BedrockLangchainPipeline")
-    assert pipeline is not None, "CodePipeline should be created"
+    template = assertions.Template.from_stack(pipeline_stack)
 
-    source_stage = pipeline.node.find_child("Source")
-    assert source_stage is not None, "Source stage should be created"
+    template.has_resource_properties("AWS::CodePipeline::Pipeline", {
+        "Stages": assertions.Match.array_with([{
+            "Name": "Source",
+            "Actions": assertions.Match.array_with([{
+                "ActionTypeId": {
+                    "Provider": "GitHub"
+                },
+                "Configuration": {
+                    "Owner": "test-owner",
+                    "Repo": "test-repo",
+                    "Branch": "main"
+                }
+            }])
+        }])
+    })
 
-    source_action = source_stage.node.find_child("CodeCommit Source")
-    assert source_action is not None, "CodeCommit source action should be created"
-
-    deploy_stage = pipeline.node.find_child("Deploy")
-    assert deploy_stage is not None, "Deploy stage should be created"
+    # Additional assertions for ValidateCloudFormation and BuildAndDeploy stages
+    template.has_resource_properties("AWS::CodeBuild::Project", {
+        "Name": "ValidateCloudFormation"
+    })
+    template.has_resource_properties("AWS::CodeBuild::Project", {
+        "Name": "BuildAndDeploy"
+    })
 
     cloudformation_action = deploy_stage.node.find_child("CloudFormation StackSet")
     assert cloudformation_action is not None, "CloudFormation StackSet action should be created"


### PR DESCRIPTION
Updates the blog and the code to remove depedency on using codecommit, as the service is now deprecated for new AWS accounts. The solution now usesGitHub as the source with webhooks